### PR TITLE
Screensaver would always be active on enterForeground

### DIFF
--- a/xbmc/platform/darwin/tvos/MainController.mm
+++ b/xbmc/platform/darwin/tvos/MainController.mm
@@ -1192,9 +1192,12 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
   {
     CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_UNPAUSE);
     m_isPlayingBeforeInactive = NO;
+  	[self disableScreenSaver];
   }
-
-  [self enableScreenSaver];
+  else
+  {
+    [self enableScreenSaver];
+  }
 }
 
 - (void)becomeInactive


### PR DESCRIPTION
switching out of the app (intentional or accidental) and going back in with a video playing would enable the screensaver